### PR TITLE
Change mysql address to dns name

### DIFF
--- a/src/mysqlprovider.py
+++ b/src/mysqlprovider.py
@@ -79,7 +79,9 @@ class MySQLProvider(ProviderBase):
             for db in missing:
                 self.charm.mysql.new_database(db)
         creds = self.credentials(rel_id)
-        creds["address"] = self.charm.unit_ip
+        app_name = self.model.app.name
+        unit_name = self.model.unit.name.replace('/', '-')
+        creds["address"] = "{}.{}-endpoints".format(unit_name, app_name)
         username = creds['username']
         logger.debug(creds)
         self.charm.mysql.new_user(creds)


### PR DESCRIPTION
Change mysql address to service name in
relation data so that the related units
configure mysql with dns name instead
of ip